### PR TITLE
Add Front-end Rescue

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Please Contribute.
 - [Devops Weekly](http://devopsweekly.com/)
 - [Django Weekly](http://djangoweek.ly/)
 - [Ember Weekly](http://emberweekly.com/)
+- [Front-end Rescue](http://us7.campaign-archive1.com/home/?u=658f6feef064b7cca5177eba6&id=4eeb350ba1)
 - [Gamedev Weekly](http://gamedevweekly.com/)
 - [Golang Weekly](http://www.golangweekly.com/)
 - [HMTL5 Weekly](http://html5weekly.com/)


### PR DESCRIPTION
Front-end Rescue is a weekly newsletter from the people who made the [Front-end Rescue](http://uptodate.frontendrescue.org/)  website. The newsletter doesn't have its own domain nor is possible to subscribe from the Front-end Rescue's website, but the provided mailchimp link is enough to subscribe and see the past issues.
