### PR TITLE
Add Cron.Weekly

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Please Contribute.
 - [Cloud Developer Weekly](http://signup.launchany.com/cloudweekly)
 - [Coder Weekly](http://www.coderweekly.com/)
 - [Container Weekly](https://tinyletter.com/containerweekly)
+- [Cron.Weekly](https://tinyletter.com/containerweekly)
 - [CSS Weekly](http://css-weekly.com/)
 - [Data Elixir](http://dataelixir.com/)
 - [Data Science Weekly](http://www.datascienceweekly.org/newsletters)


### PR DESCRIPTION
cron.weekly is a weekly newsletter, delivered to you every Sunday, with news & tools tailored to Linux sysadmins.

It features new Open Source projects, interesting blogposts and handy little CLI one-liners. cron.weekly is here for both junior as well as seasoned Linux users.